### PR TITLE
Add CI workflow and basic testing setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,13 @@
 node_modules
-npm-debug.log
+.pnp
+.pnp.js
+build
+out
+.next
+dist
+.turbo
+.env*
+yarn.lock
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'pnpm'
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Lint
+        run: pnpm lint
+      - name: Build
+        run: pnpm build
+      - name: Test
+        run: pnpm test

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": true,
+  "singleQuote": true,
+  "useTabs": false,
+  "quoteProps": "as-needed",
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS Instructions
+
+This repository is a pnpm based monorepo that contains several apps and packages.
+
+## Development guidelines
+
+- Use **Node.js v18** or newer and install dependencies with `pnpm`.
+- Preferred package manager is `pnpm@9` as defined in `package.json`.
+- Run `pnpm lint` and ensure no ESLint errors before committing.
+- Keep code formatted with Prettier (most editors can run this automatically).
+- Do not commit files listed in `.gitignore` such as build outputs or environment files.
+- Describe significant changes in the relevant `README.md` when appropriate.
+
+## Testing
+
+There are currently no automated tests in this repo. If you add tests in the future,
+provide a script named `test` in the root `package.json` and document how to run it.
+

--- a/README.md
+++ b/README.md
@@ -1,130 +1,38 @@
-# Turborepo starter with shadcn/ui
+# Merak Monorepo
 
-![Static Badge](https://img.shields.io/badge/shadcn%2Fui-0.8.0-blue?link=https%3A%2F%2Fgithub.com%2Fshadcn%2Fui)
+This repository contains the Merak protocol SDK and web application. The project uses **pnpm** and **Turborepo** to manage multiple packages.
 
-This is Turborepo starter with shadcn/ui pre-configured.
+## Apps and Packages
 
-> [!NOTE]
-> This example uses `pnpm` as package manager.
+- **apps/web** – Next.js front‑end
+- **packages/sdk** – TypeScript SDK for interacting with Merak
+- **packages/ui** – Shared React components
+- **packages/eslint-config** – Shared ESLint rules
+- **packages/typescript-config** – Shared TypeScript configuration
 
-[npm version](https://github.com/dan5py/turborepo-shadcn-ui/tree/npm)
+## Development
 
-## Using this example
+Install dependencies and start developing:
 
-Clone the repository:
-
-```sh
-git clone https://github.com/dan5py/turborepo-shadcn-ui.git
-```
-
-Install dependencies:
-
-```sh
-cd turborepo-shadcn-ui
+```bash
 pnpm install
-```
-
-### Add ui components
-
-Use the pre-made script:
-
-```sh
-pnpm ui:add <component-name>
-```
-
-> This works just like the add command in the `shadcn/ui` CLI.
-
-### Add a new app
-
-Turborepo offer a simple command to add a new app:
-
-```sh
-pnpm turbo gen workspace --name <app-name>
-```
-
-This will create a new empty app in the `apps` directory.
-
-If you want, you can copy an existing app with:
-
-```sh
-pnpm turbo gen workspace --name <app-name> --copy
-```
-
-> [!NOTE]
-> Remember to run `pnpm install` after copying an app.
-
-## What's inside?
-
-This Turborepo includes the following packages/apps:
-
-### Apps and Packages
-
-- `docs`: a [Next.js](https://nextjs.org/) app
-- `web`: another [Next.js](https://nextjs.org/) app
-- `@repo/ui`: a stub React component library shared by both `web` and `docs` applications (🚀 powered by **shadcn/ui**)
-- `@repo/eslint-config`: `eslint` configurations (includes `eslint-config-next` and `eslint-config-prettier`)
-- `@repo/typescript-config`: `tsconfig.json`s used throughout the monorepo
-
-Each package/app is 100% [TypeScript](https://www.typescriptlang.org/).
-
-### Utilities
-
-This Turborepo has some additional tools already setup for you:
-
-- [TypeScript](https://www.typescriptlang.org/) for static type checking
-- [ESLint](https://eslint.org/) for code linting
-- [Prettier](https://prettier.io) for code formatting
-
-### Build
-
-To build all apps and packages, run the following command:
-
-```sh
-cd turborepo-shadcn-ui
-pnpm build
-```
-
-### Develop
-
-To develop all apps and packages, run the following command:
-
-```sh
-cd turborepo-shadcn-ui
 pnpm dev
 ```
 
-### Remote Caching
+To build all packages:
 
-Turborepo can use a technique known as [Remote Caching](https://turbo.build/repo/docs/core-concepts/remote-caching) to share cache artifacts across machines, enabling you to share build caches with your team and CI/CD pipelines.
-
-By default, Turborepo will cache locally. To enable Remote Caching you will need an account with Vercel. If you don't have an account you can [create one](https://vercel.com/signup), then enter the following commands:
-
-```
-cd turborepo-shadcn-ui
-npx turbo login
+```bash
+pnpm build
 ```
 
-This will authenticate the Turborepo CLI with your [Vercel account](https://vercel.com/docs/concepts/personal-accounts/overview).
+### Running tests
 
-Next, you can link your Turborepo to your Remote Cache by running the following command from the root of your Turborepo:
+Tests are executed with [Vitest](https://vitest.dev/):
 
-```sh
-npx turbo link
+```bash
+pnpm test
 ```
 
-## Useful Links
+### Continuous Integration
 
-Learn more about the power of Turborepo:
-
-- [Tasks](https://turbo.build/repo/docs/core-concepts/monorepos/running-tasks)
-- [Caching](https://turbo.build/repo/docs/core-concepts/caching)
-- [Remote Caching](https://turbo.build/repo/docs/core-concepts/remote-caching)
-- [Filtering](https://turbo.build/repo/docs/core-concepts/monorepos/filtering)
-- [Configuration Options](https://turbo.build/repo/docs/reference/configuration)
-- [CLI Usage](https://turbo.build/repo/docs/reference/command-line-reference)
-
-Learn more about shadcn/ui:
-
-- [Documentation](https://ui.shadcn.com/docs)
-
-# sov-front-end-template
+A GitHub Actions workflow installs dependencies and runs `pnpm lint`, `pnpm build` and `pnpm test` for pull requests.

--- a/apps/web/__tests__/basic.test.ts
+++ b/apps/web/__tests__/basic.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('basic test', () => {
+  it('works', () => {
+    expect(1 + 1).toBe(2);
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "type-check": "tsc --noEmit",
-    "validate": "pnpm format:check && pnpm type-check"
+    "validate": "pnpm format:check && pnpm type-check",
+    "test": "vitest run"
   },
   "dependencies": {
     "@0xobelisk/merak-sdk": "^0.0.50",
@@ -63,6 +64,7 @@
     "eslint": "^9.26.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^1.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,28 +1,29 @@
 {
-	"name": "merak",
-	"version": "0.0.1",
-	"private": true,
-	"license": "MIT",
-	"scripts": {
-		"build": "turbo build",
-		"dev": "turbo dev",
-		"ui:add": "pnpm --filter @repo/ui ui:add",
-		"lint": "eslint . --max-warnings 0"
-	},
-	"dependencies": {
-		"@0xobelisk/sui-cli": "1.2.0-pre.16",
-		"@0xobelisk/sui-common": "1.2.0-pre.16",
-		"@0xobelisk/sui-indexer": "1.2.0-pre.16",
-		"chalk": "^4.1.2",
-		"dotenv": "^16.5.0"
-	},
-	"devDependencies": {
-		"@repo/eslint-config": "workspace:*",
-		"@repo/typescript-config": "workspace:*",
-		"turbo": "^2.5.3"
-	},
-	"packageManager": "pnpm@9.9.0",
-	"engines": {
-		"node": ">=18"
-	}
+  "name": "merak",
+  "version": "0.0.1",
+  "private": true,
+  "license": "MIT",
+  "scripts": {
+    "build": "turbo build",
+    "dev": "turbo dev",
+    "ui:add": "pnpm --filter @repo/ui ui:add",
+    "lint": "eslint . --max-warnings 0",
+    "test": "turbo run test"
+  },
+  "dependencies": {
+    "@0xobelisk/sui-cli": "1.2.0-pre.16",
+    "@0xobelisk/sui-common": "1.2.0-pre.16",
+    "@0xobelisk/sui-indexer": "1.2.0-pre.16",
+    "chalk": "^4.1.2",
+    "dotenv": "^16.5.0"
+  },
+  "devDependencies": {
+    "@repo/eslint-config": "workspace:*",
+    "@repo/typescript-config": "workspace:*",
+    "turbo": "^2.5.3"
+  },
+  "packageManager": "pnpm@9.9.0",
+  "engines": {
+    "node": ">=18"
+  }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -53,7 +53,8 @@
     "doc": "typedoc --out docs src/index.ts",
     "chalk": "^5.0.1",
     "prettier": "^2.8.4",
-    "prettier-plugin-rust": "^0.1.9"
+    "prettier-plugin-rust": "^0.1.9",
+    "test:unit": "vitest run"
   },
   "dependencies": {
     "@0xobelisk/sui-client": "1.2.0-pre.16",
@@ -91,7 +92,8 @@
     "tsconfig-paths": "^4.2.0",
     "tsup": "^7.2.0",
     "typedoc": "^0.25.13",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^1.5.0"
   },
   "lint-staged": {
     "**/*.ts": [
@@ -106,17 +108,6 @@
     "extends": [
       "@commitlint/config-conventional"
     ]
-  },
-  "prettier": {
-    "trailingComma": "es5",
-    "tabWidth": 2,
-    "semi": true,
-    "singleQuote": true,
-    "useTabs": false,
-    "quoteProps": "as-needed",
-    "bracketSpacing": true,
-    "arrowParens": "always",
-    "endOfLine": "lf"
   },
   "eslintConfig": {
     "root": true,

--- a/packages/sdk/test/getMerakConfig.test.ts
+++ b/packages/sdk/test/getMerakConfig.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { getMerakConfig } from '../src/utils';
+
+describe('getMerakConfig', () => {
+  it('returns testnet config', () => {
+    const cfg = getMerakConfig('testnet');
+    expect(cfg.packageId).toBeDefined();
+    expect(cfg.schemaId).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared Prettier config
- expand `.dockerignore`
- set up Vitest and example tests
- add `test` scripts in packages and root
- create GitHub Actions workflow
- update project README

## Testing
- `pnpm lint` *(failed: unable to download pnpm)*
- `pnpm test` *(failed: unable to download pnpm)*