### PR TITLE
Integrate Sentry tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS Instructions
+
+This repository is a pnpm based monorepo that contains several apps and packages.
+
+## Development guidelines
+
+- Use **Node.js v18** or newer and install dependencies with `pnpm`.
+- Preferred package manager is `pnpm@9` as defined in `package.json`.
+- Run `pnpm lint` and ensure no ESLint errors before committing.
+- Keep code formatted with Prettier (most editors can run this automatically).
+- Do not commit files listed in `.gitignore` such as build outputs or environment files.
+- Describe significant changes in the relevant `README.md` when appropriate.
+
+## Testing
+
+There are currently no automated tests in this repo. If you add tests in the future,
+provide a script named `test` in the root `package.json` and document how to run it.
+

--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ Next, you can link your Turborepo to your Remote Cache by running the following 
 npx turbo link
 ```
 
+## Error Monitoring with Sentry
+
+This project integrates [Sentry](https://sentry.io/) for runtime error tracking.
+Set the environment variable `SENTRY_DSN` (or `NEXT_PUBLIC_SENTRY_DSN` for
+browser reporting) before running the application so that errors are reported to
+your Sentry project.
+
 ## Useful Links
 
 Learn more about the power of Turborepo:

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -6,6 +6,9 @@ First, run the development server:
 pnpm dev
 ```
 
+Ensure `SENTRY_DSN` (or `NEXT_PUBLIC_SENTRY_DSN`) is set in your environment so
+that runtime errors can be reported to Sentry.
+
 Open [http://localhost:3001](http://localhost:3001) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,7 +1,8 @@
 import localFont from 'next/font/local';
+import '../sentry.server.config';
 import type { Metadata, Viewport } from 'next';
 import { Providers } from './providers';
-import { Analytics } from "@vercel/analytics/next"
+import { Analytics } from '@vercel/analytics/next';
 import '@repo/ui/globals.css';
 import '@mysten/dapp-kit/dist/index.css';
 
@@ -58,7 +59,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <Providers>
           {children}
           <Analytics />
-          </Providers>
+        </Providers>
       </body>
     </html>
   );

--- a/apps/web/app/providers.tsx
+++ b/apps/web/app/providers.tsx
@@ -1,4 +1,5 @@
 'use client';
+import '../sentry.client.config';
 
 import { createNetworkConfig, SuiClientProvider, WalletProvider } from '@mysten/dapp-kit';
 import { getFullnodeUrl } from '@mysten/sui/client';

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,6 +48,7 @@
     "react-dom": "^18.3.1",
     "react-stately": "^3.37.0",
     "sonner": "^1.7.4",
+    "@sentry/nextjs": "^7.120.3",
     "tsrpc-browser": "^3.4.16",
     "tsrpc-proto": "^1.4.3"
   },

--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -1,0 +1,6 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  tracesSampleRate: 1.0
+});

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -1,0 +1,6 @@
+import * as Sentry from '@sentry/nextjs';
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
+  tracesSampleRate: 1.0
+});


### PR DESCRIPTION
## Summary
- add Sentry to the web app
- initialize Sentry in provider and layout
- document Sentry DSN environment variable

## Testing
- `pnpm lint` *(fails: could not download pnpm)*