### PR TITLE
Add comprehensive documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 This repository contains the Merak protocol SDK and web application. The project uses **pnpm** and **Turborepo** to manage multiple packages.
 
+## Documentation
+
+Additional guides can be found in the `docs/` directory:
+- [Architecture](docs/architecture.md)
+- [Contracts](docs/contracts.md)
+- [SDK Usage](docs/sdk.md)
+- [Continuous Integration](docs/ci-cd.md)
+- [Getting Started](docs/getting-started.md)
+
 ## Apps and Packages
 
 - **apps/web** – Next.js front‑end

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -29,3 +29,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_source=github.com&utm_medium=referral&utm_campaign=turborepo-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+### Configuration
+
+Environment variables are loaded from `.env` in development. See `next.config.js` for configuration options.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,8 @@
+# Contracts
+
+Move smart contracts that power the Merak protocol are stored in this directory. Use `Move.toml` to configure compilation and deployment settings.
+
+- `merak/` – main protocol modules and tests
+- `dubhe-framework/` – helper libraries shared across Move packages
+
+Compile contracts with the Move CLI of the Sui toolchain. Contracts are independent from the TypeScript packages and are deployed separately.

--- a/contracts/dubhe-framework/README.md
+++ b/contracts/dubhe-framework/README.md
@@ -1,0 +1,3 @@
+# Dubhe Framework
+
+Helper Move modules that provide common utilities for Merak contracts. Build and test with the Sui Move CLI.

--- a/contracts/merak/README.md
+++ b/contracts/merak/README.md
@@ -1,0 +1,15 @@
+# Merak Move Package
+
+This directory contains the primary Move modules for the Merak protocol. Sources are located under `sources/` and compiled according to `Move.toml`.
+
+Use the Sui Move CLI to build and test the package:
+
+```bash
+sui move build
+```
+
+Unit tests can be executed with:
+
+```bash
+sui move test
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,20 @@
+# Architecture Overview
+
+This repository is organized as a monorepo managed with **Turborepo** and **pnpm**. Each directory under `apps/` and `packages/` represents an independent project that can share code through workspace dependencies.
+
+```
+merak/
+├─ apps/
+│  └─ web/              # Next.js front‑end
+├─ packages/
+│  ├─ sdk/              # TypeScript client library
+│  ├─ ui/               # Shared React components
+│  ├─ eslint-config/    # Reusable ESLint rules
+│  └─ typescript-config/# Shared tsconfig bases
+├─ contracts/           # Move smart contracts
+└─ docs/                # Project documentation
+```
+
+The monorepo is built with Node.js **v18** or newer. All packages use the same `pnpm-lock.yaml` and are linked through the workspace configuration defined in `pnpm-workspace.yaml`.
+
+Turborepo handles the build pipeline so tasks like `build`, `dev` and `test` run across the workspace with caching. Each package defines its own `package.json` but shares common linting and TypeScript configuration via workspace packages.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,0 +1,11 @@
+# Continuous Integration
+
+GitHub Actions is used to lint, build and test the workspace on every pull request. The workflow is defined in `.github/workflows/ci.yml` and performs the following steps:
+
+1. Checkout the repository and install Node.js v18.
+2. Install `pnpm@9` and restore cached dependencies.
+3. Run `pnpm lint` to ensure code style and formatting.
+4. Run `pnpm build` to compile all packages.
+5. Run `pnpm test` to execute unit tests if present.
+
+Use the workflow logs to debug CI failures. Keeping all packages lint-free ensures a smooth build and deployment process.

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1,0 +1,10 @@
+# Smart Contracts
+
+The `contracts/` folder contains Move modules that implement the Merak protocol. Two separate packages are currently provided:
+
+- **merak** – core modules for on-chain logic
+- **dubhe-framework** – supporting framework libraries
+
+Each package includes a `Move.toml` manifest and the contract sources under `sources/`. When making changes, be sure to update the manifests and run the appropriate Move compiler.
+
+Contracts are versioned independently from the TypeScript packages and are deployed to the Sui network. Refer to each `Move.toml` for network configuration and dependencies.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,10 @@
+# Getting Started
+
+1. Install Node.js v18 and pnpm.
+2. Run `pnpm install` from the repository root.
+3. Start the development servers:
+   ```bash
+   pnpm dev
+   ```
+4. Point your browser to http://localhost:3001 to view the web app.
+5. Run `pnpm lint` before committing changes.

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -1,0 +1,19 @@
+# SDK Usage
+
+The `@repo/sdk` package provides utilities to interact with the Merak protocol. Install it from the workspace root:
+
+```bash
+pnpm add @repo/sdk
+```
+
+A basic example:
+
+```ts
+import { MerakClient } from '@repo/sdk'
+
+const client = new MerakClient({ network: 'testnet' })
+const pools = await client.getPools()
+console.log(pools)
+```
+
+Consult the package README for additional APIs and configuration options.

--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -1,3 +1,11 @@
-# `@turbo/eslint-config`
+# `@repo/eslint-config`
 
-Collection of internal eslint configurations.
+Shared ESLint configurations used throughout the monorepo. Extend one of the provided configs in your project `.eslintrc`:
+
+```json
+{
+  "extends": ["@repo/eslint-config/next"]
+}
+```
+
+Available configs include `library`, `next` and `react-internal`. They enforce the Merak coding style and integrate Prettier formatting rules.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,1 +1,32 @@
 # Merak SDK
+
+A TypeScript client library for interacting with Merak protocol contracts. The SDK wraps common on-chain queries and transactions to provide a convenient API for JavaScript applications.
+
+## Installation
+
+```bash
+pnpm add @repo/sdk
+```
+
+## Usage
+
+```ts
+import { MerakClient } from '@repo/sdk'
+
+const client = new MerakClient({ network: 'testnet' })
+const pools = await client.getPools()
+```
+
+## Development
+
+Source code lives under `src/` and tests under `test/`. Build the package with:
+
+```bash
+pnpm build
+```
+
+Run unit tests with:
+
+```bash
+pnpm test packages/sdk
+```

--- a/packages/typescript-config/README.md
+++ b/packages/typescript-config/README.md
@@ -1,0 +1,20 @@
+# `@repo/typescript-config`
+
+This package contains shared TypeScript configuration used across the monorepo. The presets can be extended in individual `tsconfig.json` files.
+
+Available base configs:
+
+- **base.json** – default configuration for Node.js projects
+- **nextjs.json** – settings for Next.js applications
+- **react-library.json** – settings for libraries of React components
+
+To use a config, extend it in your project `tsconfig.json`:
+
+```json
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  }
+}
+```

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,1 +1,16 @@
 # `@repo/ui`
+
+Reusable React components and utility hooks shared across the Merak applications.
+
+## Development
+
+Components are located under `src/components` and are styled with Tailwind CSS. Storybook is not configured, but you can run the web app locally to preview components in use.
+
+Install dependencies and start developing:
+
+```bash
+pnpm install
+pnpm dev
+```
+
+When publishing a component library, ensure exported modules are listed in `components.json` and covered by unit tests if applicable.


### PR DESCRIPTION
## Summary
- create docs for repo structure, SDK usage, CI details and contracts
- document TypeScript config package
- expand README files across packages and contracts
- link documentation from root README

## Testing
- `pnpm lint` *(fails: EHOSTUNREACH when fetching pnpm-9.9.0.tgz)*