### PR TITLE
Improve responsive layout across pages

### DIFF
--- a/apps/web/app/bridge/page.tsx
+++ b/apps/web/app/bridge/page.tsx
@@ -321,14 +321,14 @@ export default function Page() {
     <div className="min-h-screen bg-[#F8F9FA]">
       <div className="container mx-auto px-4 py-8">
         {/* Add page title and description */}
-        <div className="max-w-[520px] mx-auto mb-6">
+        <div className="w-full max-w-lg mx-auto mb-6">
           <h1 className="text-2xl font-semibold text-gray-900">Bridge</h1>
           <p className="mt-2 text-sm text-gray-600">
             Transfer tokens between Sui and Dubhe OS networks
           </p>
         </div>
 
-        <main className="max-w-[520px] mx-auto space-y-4">
+        <main className="w-full max-w-lg mx-auto space-y-4">
           {/* First Card - Transfer Details */}
           <div className="bg-white rounded-xl shadow-sm border border-gray-100">
             <div className="px-6 py-4 border-b border-gray-100">
@@ -339,9 +339,9 @@ export default function Page() {
               {/* From Token */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">From</label>
-                <div className="flex justify-between items-center gap-4">
+                <div className="flex flex-col sm:flex-row justify-between items-center gap-4">
                   <Select defaultValue="dub">
-                    <SelectTrigger className="w-[240px] border-gray-200 bg-white">
+                    <SelectTrigger className="w-full sm:w-60 border-gray-200 bg-white">
                       <SelectValue>
                         <div className="flex items-center">
                           <img src="/dubhe-logo.png" alt="DUB logo" className="w-5 h-5 mr-2" loading="lazy" />
@@ -362,7 +362,7 @@ export default function Page() {
                   <Input
                     type="number"
                     placeholder="0.00"
-                    className="w-[240px] border-gray-200 focus:border-blue-500"
+                    className="w-full sm:w-60 border-gray-200 focus:border-blue-500"
                     value={input}
                     onChange={(e) => setInput(e.target.value)}
                   />
@@ -373,9 +373,9 @@ export default function Page() {
               {/* To Token */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">To</label>
-                <div className="flex justify-between items-center gap-4">
+                <div className="flex flex-col sm:flex-row justify-between items-center gap-4">
                   <Select defaultValue="ethereum">
-                    <SelectTrigger className="w-[240px] border-gray-200 bg-white">
+                    <SelectTrigger className="w-full sm:w-60 border-gray-200 bg-white">
                       <SelectValue>
                         <div className="flex items-center">
                           <img src="/dubhe-logo.png" alt="Dubhe logo" className="w-5 h-5 mr-2" loading="lazy" />
@@ -398,7 +398,7 @@ export default function Page() {
                     placeholder="Enter receiving address"
                     value={customAddress}
                     onChange={(e) => setCustomAddress(e.target.value)}
-                    className="w-[240px] border-gray-200 focus:border-blue-500"
+                    className="w-full sm:w-60 border-gray-200 focus:border-blue-500"
                   />
                 </div>
               </div>

--- a/apps/web/app/components/header.tsx
+++ b/apps/web/app/components/header.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link';
 import React, { useEffect } from 'react';
 import { ConnectButton, useCurrentWallet } from '@mysten/dapp-kit';
 import Image from 'next/image';
+import { Menu } from 'lucide-react';
+import { Sheet, SheetTrigger, SheetContent } from '@repo/ui/components/ui/sheet';
 import { IndexerSettings } from './settings/indexer-settings';
 import { WalletMenu } from './wallet/wallet-menu';
 
@@ -9,17 +11,16 @@ export default function Header() {
   const { currentWallet, connectionStatus } = useCurrentWallet();
 
   return (
-    <header className="flex items-center justify-between px-4 py-3 bg-transparent border-b border-gray-200">
-      <div className="flex items-center space-x-4">
+    <header className="bg-transparent border-b border-gray-200">
+      <div className="container mx-auto flex items-center justify-between px-4 py-3">
         <div className="flex items-center space-x-2">
           <Image src="/merak-logo.svg" alt="Merak Logo" width={120} height={30} priority />
         </div>
         <span className="text-xs bg-blue-100 text-blue-500 px-2 py-1 rounded-full">Testnet</span>
-      </div>
-      <nav className="hidden md:flex items-center space-x-6">
-        <Link href="/wrap" className="text-sm font-medium text-gray-600 hover:text-blue-500">
-          Wrap
-        </Link>
+        <nav className="hidden md:flex items-center space-x-6">
+          <Link href="/wrap" className="text-sm font-medium text-gray-600 hover:text-blue-500">
+            Wrap
+          </Link>
         <Link href="/swap/0/1" className="text-sm font-medium text-gray-600 hover:text-blue-500">
           Swap
         </Link>
@@ -38,22 +39,94 @@ export default function Header() {
         <Link href="/bridge" className="text-sm font-medium text-gray-600 hover:text-blue-500">
           Bridge
         </Link>
-        <Link href="https://merak-docs.obelisk.build/" className="text-sm font-medium text-gray-600 hover:text-blue-500">
+        <Link
+          href="https://merak-docs.obelisk.build/"
+          className="text-sm font-medium text-gray-600 hover:text-blue-500"
+        >
           Docs
         </Link>
         {/* <Link href="/create" className="text-sm font-medium text-gray-600 hover:text-blue-500">
           Create Token
         </Link> */}
-      </nav>
-      <div className="flex items-center space-x-4">
-        {currentWallet ? (
-          <>
-            <WalletMenu address={currentWallet.accounts[0].address} />
-            <IndexerSettings />
-          </>
-        ) : (
-          <ConnectButton className="bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-full" />
-        )}
+        </nav>
+        <Sheet>
+          <SheetTrigger asChild>
+            <button className="md:hidden p-2 rounded-md border border-gray-200">
+              <Menu className="h-6 w-6" />
+              <span className="sr-only">Open Menu</span>
+            </button>
+          </SheetTrigger>
+          <SheetContent side="left">
+            <div className="p-4 space-y-4">
+            <Link
+              href="/wrap"
+              className="block text-sm font-medium text-gray-600 hover:text-blue-500"
+            >
+              Wrap
+            </Link>
+            <Link
+              href="/swap/0/1"
+              className="block text-sm font-medium text-gray-600 hover:text-blue-500"
+            >
+              Swap
+            </Link>
+            <Link
+              href="/pool"
+              className="block text-sm font-medium text-gray-600 hover:text-blue-500"
+            >
+              Pool
+            </Link>
+            <Link
+              href="/positions"
+              className="block text-sm font-medium text-gray-600 hover:text-blue-500"
+            >
+              Positions
+            </Link>
+            <Link
+              href="/assets"
+              className="block text-sm font-medium text-gray-600 hover:text-blue-500"
+            >
+              Assets
+            </Link>
+            <Link
+              href="/portfolio"
+              className="block text-sm font-medium text-gray-600 hover:text-blue-500"
+            >
+              Portfolio
+            </Link>
+            <Link
+              href="/bridge"
+              className="block text-sm font-medium text-gray-600 hover:text-blue-500"
+            >
+              Bridge
+            </Link>
+            <Link
+              href="https://merak-docs.obelisk.build/"
+              className="block text-sm font-medium text-gray-600 hover:text-blue-500"
+            >
+              Docs
+            </Link>
+            {currentWallet ? (
+              <div className="flex flex-col space-y-2">
+                <WalletMenu address={currentWallet.accounts[0].address} />
+                <IndexerSettings />
+              </div>
+            ) : (
+              <ConnectButton className="bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-full" />
+            )}
+          </div>
+        </SheetContent>
+      </Sheet>
+        <div className="hidden md:flex items-center space-x-4">
+          {currentWallet ? (
+            <>
+              <WalletMenu address={currentWallet.accounts[0].address} />
+              <IndexerSettings />
+            </>
+          ) : (
+            <ConnectButton className="bg-blue-500 hover:bg-blue-600 text-white font-medium py-2 px-4 rounded-full" />
+          )}
+        </div>
       </div>
     </header>
   );

--- a/apps/web/app/components/pool/liquidity-pools.tsx
+++ b/apps/web/app/components/pool/liquidity-pools.tsx
@@ -406,7 +406,7 @@ export default function LiquidityPools() {
         )}
       </div>
       <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
-        <DialogContent className="sm:max-w-[425px]">
+        <DialogContent className="sm:max-w-sm">
           {currentStep === 'select' ? (
             <TokenCreate onClose={handleCloseModal} onSelectTokens={handleSelectTokens} />
           ) : (

--- a/apps/web/app/components/settings/indexer-settings.tsx
+++ b/apps/web/app/components/settings/indexer-settings.tsx
@@ -153,7 +153,7 @@ export function IndexerSettings() {
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
-        className="w-[360px] bg-white dark:bg-[#18181B] border border-gray-100 dark:border-gray-800"
+        className="w-full sm:w-80 bg-white dark:bg-[#18181B] border border-gray-100 dark:border-gray-800"
         align="end"
       >
         <DropdownMenuLabel className="text-xl font-semibold text-gray-900 dark:text-gray-100">

--- a/apps/web/app/components/swap/token-selection-modal.tsx
+++ b/apps/web/app/components/swap/token-selection-modal.tsx
@@ -151,7 +151,7 @@ function TokenSelectionModalOpen({
 
   return (
     <div className="fixed inset-0 bg-black/20 backdrop-blur-sm flex items-center justify-center p-4 z-[1000]">
-      <div className="bg-white rounded-3xl w-full max-w-[480px] relative">
+      <div className="bg-white rounded-3xl w-full max-w-md relative">
         <div className="p-6">
           <div className="flex justify-between items-center mb-3">
             <h2 className="text-xl font-semibold text-gray-900">Select a token</h2>

--- a/apps/web/app/components/wrap/wrap.tsx
+++ b/apps/web/app/components/wrap/wrap.tsx
@@ -505,7 +505,7 @@ export default function TokenWrapper() {
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-[#F7F8FA] p-4">
-      <Card className="w-[400px] border-gray-200 shadow-sm">
+      <Card className="w-full max-w-md border-gray-200 shadow-sm">
         <CardContent className="pt-6">
           <form className="space-y-4" onSubmit={(e) => e.preventDefault()}>
             <div className="flex items-center justify-between">

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -45,7 +45,9 @@ export const metadata: Metadata = {
 };
 
 export const viewport: Viewport = {
-  themeColor: '#fff'
+  themeColor: '#fff',
+  width: 'device-width',
+  initialScale: 1
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/apps/web/app/portfolio/page.tsx
+++ b/apps/web/app/portfolio/page.tsx
@@ -1823,7 +1823,7 @@ function AssetActionDialog({
 }: AssetActionDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent className="sm:max-w-sm">
         <DialogHeader>
           <DialogTitle>Confirm Action</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
## Summary
- add container wrapper to `Header`
- adjust `Bridge` page inputs for small screens
- make wrap form card fit narrow viewports
- fix dialog widths for pool creation and portfolio
- tweak settings dropdown and token selection modal

## Testing
- `pnpm lint` *(fails: unable to download pnpm)*